### PR TITLE
Return an error rather than panicking on a bad request.

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -7,6 +7,10 @@ The queue implemented here is as fast as it is for an additional reason: it is *
 */
 package queue
 
+import (
+	"errors"
+)
+
 const minQueueLen = 16
 
 // Queue represents a single instance of the queue data structure.
@@ -57,27 +61,27 @@ func (q *Queue) Add(elem interface{}) {
 
 // Peek returns the element at the head of the queue. This call panics
 // if the queue is empty.
-func (q *Queue) Peek() interface{} {
+func (q *Queue) Peek() (interface{}, error) {
 	if q.count <= 0 {
-		panic("queue: Peek() called on empty queue")
+		return nil, errors.New("queue: Peek() called on empty queue")
 	}
-	return q.buf[q.head]
+	return q.buf[q.head], nil
 }
 
 // Get returns the element at index i in the queue. If the index is
 // invalid, the call will panic.
-func (q *Queue) Get(i int) interface{} {
+func (q *Queue) Get(i int) (interface{}, error) {
 	if i < 0 || i >= q.count {
-		panic("queue: Get() called with index out of range")
+		return nil, errors.New("queue: Get() called with index out of range")
 	}
-	return q.buf[(q.head+i)%len(q.buf)]
+	return q.buf[(q.head+i)%len(q.buf)], nil
 }
 
 // Remove removes the element from the front of the queue. If you actually
 // want the element, call Peek first. This call panics if the queue is empty.
-func (q *Queue) Remove() {
+func (q *Queue) Remove() error {
 	if q.count <= 0 {
-		panic("queue: Remove() called on empty queue")
+		return errors.New("queue: Remove() called on empty queue")
 	}
 	q.buf[q.head] = nil
 	q.head = (q.head + 1) % len(q.buf)
@@ -85,4 +89,6 @@ func (q *Queue) Remove() {
 	if len(q.buf) > minQueueLen && q.count*4 == len(q.buf) {
 		q.resize()
 	}
+
+	return nil
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -9,8 +9,8 @@ func TestQueueSimple(t *testing.T) {
 		q.Add(i)
 	}
 	for i := 0; i < minQueueLen; i++ {
-		if q.Peek().(int) != i {
-			t.Error("peek", i, "had value", q.Peek())
+		if e, _ := q.Peek(); e.(int) != i {
+			t.Error("peek", i, "had value", e)
 		}
 		q.Remove()
 	}
@@ -28,8 +28,8 @@ func TestQueueWrapping(t *testing.T) {
 	}
 
 	for i := 0; i < minQueueLen; i++ {
-		if q.Peek().(int) != i+3 {
-			t.Error("peek", i, "had value", q.Peek())
+		if e, _ := q.Peek(); e.(int) != i+3 {
+			t.Error("peek", i, "had value", e)
 		}
 		q.Remove()
 	}
@@ -62,67 +62,59 @@ func TestQueueGet(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		q.Add(i)
 		for j := 0; j < q.Length(); j++ {
-			if q.Get(j).(int) != j {
+			if e, _ := q.Get(j); e.(int) != j {
 				t.Errorf("index %d doesn't contain %d", j, j)
 			}
 		}
 	}
 }
 
-func TestQueueGetOutOfRangePanics(t *testing.T) {
+func TestQueueGetOutOfRangeErrors(t *testing.T) {
 	q := New()
 
 	q.Add(1)
 	q.Add(2)
 	q.Add(3)
 
-	assertPanics(t, "should panic when negative index", func() {
-		q.Get(-1)
-	})
+	_, err := q.Get(-1)
+	if err == nil {
+		t.Error("should haved errored when negative index")
+	}
 
-	assertPanics(t, "should panic when index greater than length", func() {
-		q.Get(4)
-	})
+	_, err = q.Get(4)
+	if err == nil {
+		t.Error("should haved errored when negative index")
+	}
 }
 
-func TestQueuePeekOutOfRangePanics(t *testing.T) {
+func TestQueuePeekOutOfRangeErrors(t *testing.T) {
 	q := New()
 
-	assertPanics(t, "should panic when peeking empty queue", func() {
-		q.Peek()
-	})
+	if _, err := q.Peek(); err == nil {
+		t.Error("should error when peeking empty queue")
+	}
 
 	q.Add(1)
 	q.Remove()
 
-	assertPanics(t, "should panic when peeking emptied queue", func() {
-		q.Peek()
-	})
+	if _, err := q.Peek(); err == nil {
+		t.Error("should error when peeking emptied queue")
+	}
 }
 
-func TestQueueRemoveOutOfRangePanics(t *testing.T) {
+func TestQueueRemoveOutOfRangeErrors(t *testing.T) {
 	q := New()
 
-	assertPanics(t, "should panic when removing empty queue", func() {
-		q.Remove()
-	})
+	if q.Remove() == nil {
+		t.Error("should error when removing empty queue")
+	}
 
 	q.Add(1)
 	q.Remove()
 
-	assertPanics(t, "should panic when removing emptied queue", func() {
-		q.Remove()
-	})
-}
-
-func assertPanics(t *testing.T, name string, f func()) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("%s: didn't panic as expected", name)
-		}
-	}()
-
-	f()
+	if q.Remove() == nil {
+		t.Error("should error when removing emptied queue")
+	}
 }
 
 // General warning: Go's benchmark utility (go test -bench .) increases the number of


### PR DESCRIPTION
It's considered much more idiomatic to return errors rather than panicking if something goes wrong. It might actually be _dangerous_ to panic here... the expectation is that if there's a possiblity for an error, an error will be returned. If consumers don't see that an error is returned, they may simply assume `nil` is returned on an invalid request, and applications will burn...

Unfortunately this is not a backwards-compatible change.