### PR TITLE
Pop

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -73,6 +73,13 @@ func (q *Queue) Get(i int) interface{} {
 	return q.buf[(q.head+i)%len(q.buf)]
 }
 
+func (q *Queue) Pop() interface{} {
+	item := q.Peek()
+	q.Remove()
+
+	return item
+}
+
 // Remove removes the element from the front of the queue. If you actually
 // want the element, call Peek first. This call panics if the queue is empty.
 func (q *Queue) Remove() {

--- a/queue_test.go
+++ b/queue_test.go
@@ -69,6 +69,20 @@ func TestQueueGet(t *testing.T) {
 	}
 }
 
+func TestQueuePops(t *testing.T) {
+	q := New()
+
+	for i := 0; i < 1000; i++ {
+		q.Add(i)
+	}
+
+	for i := 0; i < 1000; i++ {
+		if q.Pop() != i {
+			t.Errorf("index %d doesn't contain %d", i, i)
+		}
+	}
+}
+
 func TestQueueGetOutOfRangePanics(t *testing.T) {
 	q := New()
 


### PR DESCRIPTION
Probably the most common means to consume a queue is popping off the first element -- removing and returning the head -- so I added a helper method called Pop() which does just that.

Depends on my previous #6, and is partly build for #8 so that we only need to acquire a single lock for common use cases.