### PR TITLE
Threadsafe Queue Implementation 

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -77,6 +77,16 @@ func (q *Queue) Get(i int) (interface{}, error) {
 	return q.buf[(q.head+i)%len(q.buf)], nil
 }
 
+// Gets and returns the first item from the queue.
+func (q *Queue) Pop() (interface{}, error) {
+	item, err := q.Peek()
+	if err != nil {
+		return nil, err
+	}
+
+	return item, q.Remove()
+}
+
 // Remove removes the element from the front of the queue. If you actually
 // want the element, call Peek first. This call panics if the queue is empty.
 func (q *Queue) Remove() error {

--- a/queue.go
+++ b/queue.go
@@ -7,6 +7,10 @@ The queue implemented here is as fast as it is for an additional reason: it is *
 */
 package queue
 
+import (
+	"errors"
+)
+
 const minQueueLen = 16
 
 // Queue represents a single instance of the queue data structure.
@@ -57,27 +61,27 @@ func (q *Queue) Add(elem interface{}) {
 
 // Peek returns the element at the head of the queue. This call panics
 // if the queue is empty.
-func (q *Queue) Peek() interface{} {
+func (q *Queue) Peek() (interface{}, error) {
 	if q.count <= 0 {
-		panic("queue: Peek() called on empty queue")
+		return nil, errors.New("queue: Peek() called on empty queue")
 	}
-	return q.buf[q.head]
+	return q.buf[q.head], nil
 }
 
 // Get returns the element at index i in the queue. If the index is
 // invalid, the call will panic.
-func (q *Queue) Get(i int) interface{} {
+func (q *Queue) Get(i int) (interface{}, error) {
 	if i < 0 || i >= q.count {
-		panic("queue: Get() called with index out of range")
+		return nil, errors.New("queue: Get() called with index out of range")
 	}
-	return q.buf[(q.head+i)%len(q.buf)]
+	return q.buf[(q.head+i)%len(q.buf)], nil
 }
 
 // Remove removes the element from the front of the queue. If you actually
 // want the element, call Peek first. This call panics if the queue is empty.
-func (q *Queue) Remove() {
+func (q *Queue) Remove() error {
 	if q.count <= 0 {
-		panic("queue: Remove() called on empty queue")
+		return errors.New("queue: Remove() called on empty queue")
 	}
 	q.buf[q.head] = nil
 	q.head = (q.head + 1) % len(q.buf)
@@ -85,4 +89,6 @@ func (q *Queue) Remove() {
 	if len(q.buf) > minQueueLen && q.count*4 == len(q.buf) {
 		q.resize()
 	}
+
+	return nil
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -69,6 +69,20 @@ func TestQueueGet(t *testing.T) {
 	}
 }
 
+func TestQueuePops(t *testing.T) {
+	q := New()
+
+	for i := 0; i < 1000; i++ {
+		q.Add(i)
+	}
+
+	for i := 0; i < 1000; i++ {
+		if e, _ := q.Pop(); e != i {
+			t.Errorf("index %d doesn't contain %d", i, i)
+		}
+	}
+}
+
 func TestQueueGetOutOfRangeErrors(t *testing.T) {
 	q := New()
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -9,8 +9,8 @@ func TestQueueSimple(t *testing.T) {
 		q.Add(i)
 	}
 	for i := 0; i < minQueueLen; i++ {
-		if q.Peek().(int) != i {
-			t.Error("peek", i, "had value", q.Peek())
+		if e, _ := q.Peek(); e.(int) != i {
+			t.Error("peek", i, "had value", e)
 		}
 		q.Remove()
 	}
@@ -28,8 +28,8 @@ func TestQueueWrapping(t *testing.T) {
 	}
 
 	for i := 0; i < minQueueLen; i++ {
-		if q.Peek().(int) != i+3 {
-			t.Error("peek", i, "had value", q.Peek())
+		if e, _ := q.Peek(); e.(int) != i+3 {
+			t.Error("peek", i, "had value", e)
 		}
 		q.Remove()
 	}
@@ -62,67 +62,59 @@ func TestQueueGet(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		q.Add(i)
 		for j := 0; j < q.Length(); j++ {
-			if q.Get(j).(int) != j {
+			if e, _ := q.Get(j); e.(int) != j {
 				t.Errorf("index %d doesn't contain %d", j, j)
 			}
 		}
 	}
 }
 
-func TestQueueGetOutOfRangePanics(t *testing.T) {
+func TestQueueGetOutOfRangeErrors(t *testing.T) {
 	q := New()
 
 	q.Add(1)
 	q.Add(2)
 	q.Add(3)
 
-	assertPanics(t, "should panic when negative index", func() {
-		q.Get(-1)
-	})
+	_, err := q.Get(-1)
+	if err == nil {
+		t.Error("should haved errored when negative index")
+	}
 
-	assertPanics(t, "should panic when index greater than length", func() {
-		q.Get(4)
-	})
+	_, err = q.Get(4)
+	if err == nil {
+		t.Error("should haved errored when negative index")
+	}
 }
 
-func TestQueuePeekOutOfRangePanics(t *testing.T) {
+func TestQueuePeekOutOfRangeErrors(t *testing.T) {
 	q := New()
 
-	assertPanics(t, "should panic when peeking empty queue", func() {
-		q.Peek()
-	})
+	if _, err := q.Peek(); err == nil {
+		t.Error("should error when peeking empty queue")
+	}
 
 	q.Add(1)
 	q.Remove()
 
-	assertPanics(t, "should panic when peeking emptied queue", func() {
-		q.Peek()
-	})
+	if _, err := q.Peek(); err == nil {
+		t.Error("should error when peeking emptied queue")
+	}
 }
 
-func TestQueueRemoveOutOfRangePanics(t *testing.T) {
+func TestQueueRemoveOutOfRangeErrors(t *testing.T) {
 	q := New()
 
-	assertPanics(t, "should panic when removing empty queue", func() {
-		q.Remove()
-	})
+	if q.Remove() == nil {
+		t.Error("should error when removing empty queue")
+	}
 
 	q.Add(1)
 	q.Remove()
 
-	assertPanics(t, "should panic when removing emptied queue", func() {
-		q.Remove()
-	})
-}
-
-func assertPanics(t *testing.T, name string, f func()) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("%s: didn't panic as expected", name)
-		}
-	}()
-
-	f()
+	if q.Remove() == nil {
+		t.Error("should error when removing emptied queue")
+	}
 }
 
 // General warning: Go's benchmark utility (go test -bench .) increases the number of

--- a/threadsafe.go
+++ b/threadsafe.go
@@ -1,0 +1,71 @@
+package queue
+
+import (
+	"sync"
+)
+
+// A threadsafe queue is Queue structure, wrapped with modifications
+// to make it thread safe.
+type ThreadSafeQueue struct {
+	q    *Queue
+	lock *sync.Mutex
+}
+
+// Creates and returns a new thread safe queue.
+func NewThreadSafe() *ThreadSafeQueue {
+	return &ThreadSafeQueue{
+		q:    New(),
+		lock: new(sync.Mutex),
+	}
+}
+
+// Length returns the number of elements currently stored in the queue.
+func (t *ThreadSafeQueue) Length() int {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.q.Length()
+}
+
+// Add puts an element on the end of the queue.
+func (t *ThreadSafeQueue) Add(elem interface{}) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.q.Add(elem)
+}
+
+// Peek returns the element at the head of the queue. This call errors
+// if the queue is empty.
+func (t *ThreadSafeQueue) Peek() (interface{}, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.q.Peek()
+}
+
+// Get returns the element at index i in the queue. If the index is
+// invalid, the call will error.
+func (t *ThreadSafeQueue) Get(i int) (interface{}, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.q.Get(i)
+}
+
+// Gets and returns the first item from the queue.
+func (t *ThreadSafeQueue) Pop() (interface{}, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.q.Pop()
+}
+
+// Remove removes the element from the front of the queue. If you actually
+// want the element, call Peek first. This call errors if the queue is empty.
+func (t *ThreadSafeQueue) Remove() error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.q.Remove()
+}

--- a/threadsafe_test.go
+++ b/threadsafe_test.go
@@ -1,0 +1,168 @@
+package queue
+
+import "testing"
+
+func TestTsQueueSimple(t *testing.T) {
+	q := NewThreadSafe()
+
+	for i := 0; i < minQueueLen; i++ {
+		q.Add(i)
+	}
+	for i := 0; i < minQueueLen; i++ {
+		if e, _ := q.Peek(); e.(int) != i {
+			t.Error("peek", i, "had value", e)
+		}
+		q.Remove()
+	}
+}
+
+func TestTsQueueWrapping(t *testing.T) {
+	q := NewThreadSafe()
+
+	for i := 0; i < minQueueLen; i++ {
+		q.Add(i)
+	}
+	for i := 0; i < 3; i++ {
+		q.Remove()
+		q.Add(minQueueLen + i)
+	}
+
+	for i := 0; i < minQueueLen; i++ {
+		if e, _ := q.Peek(); e.(int) != i+3 {
+			t.Error("peek", i, "had value", e)
+		}
+		q.Remove()
+	}
+}
+
+func TestTsQueueLength(t *testing.T) {
+	q := NewThreadSafe()
+
+	if q.Length() != 0 {
+		t.Error("empty queue length not 0")
+	}
+
+	for i := 0; i < 1000; i++ {
+		q.Add(i)
+		if q.Length() != i+1 {
+			t.Error("adding: queue with", i, "elements has length", q.Length())
+		}
+	}
+	for i := 0; i < 1000; i++ {
+		q.Remove()
+		if q.Length() != 1000-i-1 {
+			t.Error("removing: queue with", 1000-i-i, "elements has length", q.Length())
+		}
+	}
+}
+
+func TestTsQueueGet(t *testing.T) {
+	q := NewThreadSafe()
+
+	for i := 0; i < 1000; i++ {
+		q.Add(i)
+		for j := 0; j < q.Length(); j++ {
+			if e, _ := q.Get(j); e.(int) != j {
+				t.Errorf("index %d doesn't contain %d", j, j)
+			}
+		}
+	}
+}
+
+func TestTsQueuePops(t *testing.T) {
+	q := NewThreadSafe()
+
+	for i := 0; i < 1000; i++ {
+		q.Add(i)
+	}
+
+	for i := 0; i < 1000; i++ {
+		if e, _ := q.Pop(); e != i {
+			t.Errorf("index %d doesn't contain %d", i, i)
+		}
+	}
+}
+
+func TestTsQueueGetOutOfRangeErrors(t *testing.T) {
+	q := NewThreadSafe()
+
+	q.Add(1)
+	q.Add(2)
+	q.Add(3)
+
+	_, err := q.Get(-1)
+	if err == nil {
+		t.Error("should haved errored when negative index")
+	}
+
+	_, err = q.Get(4)
+	if err == nil {
+		t.Error("should haved errored when negative index")
+	}
+}
+
+func TestTsQueuePeekOutOfRangeErrors(t *testing.T) {
+	q := NewThreadSafe()
+
+	if _, err := q.Peek(); err == nil {
+		t.Error("should error when peeking empty queue")
+	}
+
+	q.Add(1)
+	q.Remove()
+
+	if _, err := q.Peek(); err == nil {
+		t.Error("should error when peeking emptied queue")
+	}
+}
+
+func TestTsQueueRemoveOutOfRangeErrors(t *testing.T) {
+	q := NewThreadSafe()
+
+	if q.Remove() == nil {
+		t.Error("should error when removing empty queue")
+	}
+
+	q.Add(1)
+	q.Remove()
+
+	if q.Remove() == nil {
+		t.Error("should error when removing emptied queue")
+	}
+}
+
+// General warning: Go's benchmark utility (go test -bench .) increases the number of
+// iterations until the benchmarks take a reasonable amount of time to run; memory usage
+// is *NOT* considered. On my machine, these benchmarks hit around ~1GB before they've had
+// enough, but if you have less than that available and start swapping, then all bets are off.
+
+func BenchmarkTsQueueSerial(b *testing.B) {
+	q := NewThreadSafe()
+	for i := 0; i < b.N; i++ {
+		q.Add(nil)
+	}
+	for i := 0; i < b.N; i++ {
+		q.Peek()
+		q.Remove()
+	}
+}
+
+func BenchmarkTsQueueGet(b *testing.B) {
+	q := NewThreadSafe()
+	for i := 0; i < b.N; i++ {
+		q.Add(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q.Get(i)
+	}
+}
+
+func BenchmarkTsQueueTickTock(b *testing.B) {
+	q := NewThreadSafe()
+	for i := 0; i < b.N; i++ {
+		q.Add(nil)
+		q.Peek()
+		q.Remove()
+	}
+}


### PR DESCRIPTION
Now for what I originally came here for ;)

Added a very basic threadsafe implementation of the queue, which surprisingly doesn't have _too_ huge a performance overhead. This is dependent on my previous two PRs (prevent merge conflicts, if they're accepted), but if you want to merge this but not those two, I'll resubmit a version without those changes.

```
➜  queue git:(pop) ✗ go test -bench=.
PASS
BenchmarkQueueSerial     10000000          334 ns/op
BenchmarkQueueGet        50000000         29.7 ns/op
BenchmarkQueueTickTock   30000000         56.3 ns/op
BenchmarkTsQueueSerial   2000000           651 ns/op
BenchmarkTsQueueGet      10000000          204 ns/op
BenchmarkTsQueueTickTock 3000000           585 ns/op
ok      github.com/connor4312/queue 36.370s
```