### PR TITLE
Get() allows negative index.  Use modular math for speed.  Add Pop() …

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -7,6 +7,8 @@ The queue implemented here is as fast as it is for an additional reason: it is *
 */
 package queue
 
+// minQueueLen is smallest capacity that queue may have.
+// Must be power of 2 for modular arithmetic.
 const minQueueLen = 16
 
 // Queue represents a single instance of the queue data structure.
@@ -27,10 +29,16 @@ func (q *Queue) Length() int {
 	return q.count
 }
 
+// Capacity returns the maximum number of elements that the queue can store
+// before increasing allocated storage.
+func (q *Queue) Capacity() int {
+	return len(q.buf)
+}
+
 // resizes the queue to fit exactly twice its current contents
 // this can result in shrinking if the queue is less than half-full
 func (q *Queue) resize() {
-	newBuf := make([]interface{}, q.count*2)
+	newBuf := make([]interface{}, q.count<<1)
 
 	if q.tail > q.head {
 		copy(newBuf, q.buf[q.head:q.tail])
@@ -51,7 +59,9 @@ func (q *Queue) Add(elem interface{}) {
 	}
 
 	q.buf[q.tail] = elem
-	q.tail = (q.tail + 1) % len(q.buf)
+	// Compute modulus bitwise since len(q.buf) is always a power of 2:
+	// x % n == x & (n - 1)
+	q.tail = (q.tail + 1) & (len(q.buf) - 1)
 	q.count++
 }
 
@@ -65,12 +75,18 @@ func (q *Queue) Peek() interface{} {
 }
 
 // Get returns the element at index i in the queue. If the index is
-// invalid, the call will panic.
+// invalid, the call will panic. This method accepts both positive and
+// negative index values. Index 0 refers to the first element, and
+// index -1 refers to the last.
 func (q *Queue) Get(i int) interface{} {
+	// If indexing backwards, convert to positive index.
+	if i < 0 {
+		i = q.count + i
+	}
 	if i < 0 || i >= q.count {
 		panic("queue: Get() called with index out of range")
 	}
-	return q.buf[(q.head+i)%len(q.buf)]
+	return q.buf[(q.head+i)&(len(q.buf)-1)]
 }
 
 // Remove removes the element from the front of the queue. If you actually
@@ -80,9 +96,45 @@ func (q *Queue) Remove() {
 		panic("queue: Remove() called on empty queue")
 	}
 	q.buf[q.head] = nil
-	q.head = (q.head + 1) % len(q.buf)
+	// Compute modulus bitwise since len(q.buf) is always a power of 2:
+	// x % n == x & (n - 1)
+	q.head = (q.head + 1) & (len(q.buf) - 1)
 	q.count--
-	if len(q.buf) > minQueueLen && q.count*4 == len(q.buf) {
+	// Resize down if buffer 1/4 full.
+	if len(q.buf) > minQueueLen && (q.count<<2) == len(q.buf) {
 		q.resize()
 	}
+}
+
+// Pop removes and returns the element from the front of (first in) the queue.
+// If the queue is empty, returns nil and false to indicate the queue was empty
+// and no data was returned.
+func (q *Queue) Pop() (interface{}, bool) {
+	if q.count <= 0 {
+		return nil, false
+	}
+	ret := q.buf[q.head]
+	q.buf[q.head] = nil
+	// Compute modulus bitwise since len(q.buf) is always a power of 2:
+	// x % n == x & (n - 1)
+	q.head = (q.head + 1) & (len(q.buf) - 1)
+	q.count--
+	// Resize down if buffer 1/4 full.
+	if len(q.buf) > minQueueLen && (q.count<<2) == len(q.buf) {
+		q.resize()
+	}
+	return ret, true
+}
+
+// Clear removes all elements from the queue, but retains the current capacity.
+func (q *Queue) Clear() {
+	// Compute modulus bitwise since len(q.buf) is always a power of 2:
+	// x % n == x & (n - 1)
+	blen := len(q.buf) - 1
+	for h := q.head; h != q.tail; h = (h + 1) & blen {
+		q.buf[h] = nil
+	}
+	q.head = 0
+	q.tail = 0
+	q.count = 0
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -76,8 +76,8 @@ func TestQueueGetOutOfRangePanics(t *testing.T) {
 	q.Add(2)
 	q.Add(3)
 
-	assertPanics(t, "should panic when negative index", func() {
-		q.Get(-1)
+	assertPanics(t, "should panic when negative index greater than length", func() {
+		q.Get(-4)
 	})
 
 	assertPanics(t, "should panic when index greater than length", func() {
@@ -113,6 +113,33 @@ func TestQueueRemoveOutOfRangePanics(t *testing.T) {
 	assertPanics(t, "should panic when removing emptied queue", func() {
 		q.Remove()
 	})
+}
+
+func TestQueueClear(t *testing.T) {
+	q := New()
+
+	for i := 0; i < 100; i++ {
+		q.Add(i)
+	}
+	if q.Length() != 100 {
+		t.Error("push: queue with 100 elements has length", q.Length())
+	}
+	cap := q.Capacity()
+	q.Clear()
+	if q.Length() != 0 {
+		t.Error("empty queue length not 0 after clear")
+	}
+	if q.Capacity() != cap {
+		t.Error("queue capacity changed after clear")
+	}
+
+	// Check that there are no remaining references after Clear()
+	for i := 0; i < q.Capacity(); i++ {
+		if q.buf[i] != nil {
+			t.Error("queue has non-nil deleted elements after Clear()")
+			break
+		}
+	}
 }
 
 func assertPanics(t *testing.T, name string, f func()) {


### PR DESCRIPTION
…and Clear() methods and unit tests.

Please consider the changes proposed in this PR, as I have found them to be useful extensions of queue, and would like offer them for inclusion in your code base if you find any or all of them useful/acceptable.
- Negative indexing for Get() is very useful in some cases.
- Benchmarking shows that modular math makes implementation slightly faster.
- Pop() is sometimes useful instead of separate Peek() and Remove(), and when a preceeding check for empty queue is not wanted.
- Clear() is useful for emptying the queue without provoking GC due to capacity resizing.