### PR TITLE
Suggest Pop() function

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -99,18 +99,6 @@ func (q *Queue) Remove() {
 	}
 }
 
-// Clear removes all elements from the queue, but retains the current capacity.
-func (q *Queue) Clear() {
-	// bitwise modulus
-	mbits := len(q.buf) - 1
-	for h := q.head; h != q.tail; h = (h + 1) & mbits {
-		q.buf[h] = nil
-	}
-	q.head = 0
-	q.tail = 0
-	q.count = 0
-}
-
 // Pop removes and returns the element from the front of the queue. If the
 // queue is empty, the call will panic.
 func (q *Queue) Pop() interface{} {

--- a/queue.go
+++ b/queue.go
@@ -98,3 +98,15 @@ func (q *Queue) Remove() {
 		q.resize()
 	}
 }
+
+// Clear removes all elements from the queue, but retains the current capacity.
+func (q *Queue) Clear() {
+	// bitwise modulus
+	mbits := len(q.buf) - 1
+	for h := q.head; h != q.tail; h = (h + 1) & mbits {
+		q.buf[h] = nil
+	}
+	q.head = 0
+	q.tail = 0
+	q.count = 0
+}

--- a/queue.go
+++ b/queue.go
@@ -110,3 +110,21 @@ func (q *Queue) Clear() {
 	q.tail = 0
 	q.count = 0
 }
+
+// Pop removes and returns the element from the front of the queue. If the
+// queue is empty, the call will panic.
+func (q *Queue) Pop() interface{} {
+	if q.count <= 0 {
+		panic("queue: Pop() called on empty queue")
+	}
+	ret := q.buf[q.head]
+	q.buf[q.head] = nil
+	// bitwise modulus
+	q.head = (q.head + 1) & (len(q.buf) - 1)
+	q.count--
+	// Resize down if buffer 1/4 full.
+	if len(q.buf) > minQueueLen && (q.count<<2) == len(q.buf) {
+		q.resize()
+	}
+	return ret
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -82,6 +82,34 @@ func TestQueueGetNegative(t *testing.T) {
 	}
 }
 
+func TestQueueClear(t *testing.T) {
+	q := New()
+
+	q.Clear()
+	for i := 0; i < 100; i++ {
+		q.Add(i)
+	}
+	if q.Length() != 100 {
+		t.Error("push: queue with 100 elements has length", q.Length())
+	}
+	cap := len(q.buf)
+	q.Clear()
+	if q.Length() != 0 {
+		t.Error("empty queue length not 0 after clear")
+	}
+	if len(q.buf) != cap {
+		t.Error("queue capacity changed after clear")
+	}
+
+	// Check that there are no remaining references after Clear()
+	for i := 0; i < len(q.buf); i++ {
+		if q.buf[i] != nil {
+			t.Error("queue has non-nil deleted elements after Clear()")
+			break
+		}
+	}
+}
+
 func TestQueueGetOutOfRangePanics(t *testing.T) {
 	q := New()
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -91,34 +91,6 @@ func TestQueueGetNegative(t *testing.T) {
 	}
 }
 
-func TestQueueClear(t *testing.T) {
-	q := New()
-
-	q.Clear()
-	for i := 0; i < 100; i++ {
-		q.Add(i)
-	}
-	if q.Length() != 100 {
-		t.Error("push: queue with 100 elements has length", q.Length())
-	}
-	cap := len(q.buf)
-	q.Clear()
-	if q.Length() != 0 {
-		t.Error("empty queue length not 0 after clear")
-	}
-	if len(q.buf) != cap {
-		t.Error("queue capacity changed after clear")
-	}
-
-	// Check that there are no remaining references after Clear()
-	for i := 0; i < len(q.buf); i++ {
-		if q.buf[i] != nil {
-			t.Error("queue has non-nil deleted elements after Clear()")
-			break
-		}
-	}
-}
-
 func TestQueueGetOutOfRangePanics(t *testing.T) {
 	q := New()
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -14,6 +14,15 @@ func TestQueueSimple(t *testing.T) {
 		}
 		q.Remove()
 	}
+
+	for i := 0; i < minQueueLen; i++ {
+		q.Add(i)
+	}
+	for i := 0; i < minQueueLen; i++ {
+		if q.Pop().(int) != i {
+			t.Error("peek", i, "had value", q.Peek())
+		}
+	}
 }
 
 func TestQueueWrapping(t *testing.T) {
@@ -156,6 +165,24 @@ func TestQueueRemoveOutOfRangePanics(t *testing.T) {
 	})
 }
 
+func TestQueuePopOutOfRangePanics(t *testing.T) {
+	q := New()
+
+	assertPanics(t, "should panic when popping empty queue", func() {
+		q.Pop()
+	})
+
+	q.Add(1)
+	x := q.Pop()
+	if x != 1 {
+		t.Fatal("Pop() returned wrong value")
+	}
+
+	assertPanics(t, "should panic when popping emptied queue", func() {
+		q.Remove()
+	})
+}
+
 func assertPanics(t *testing.T, name string, f func()) {
 	defer func() {
 		if r := recover(); r == nil {
@@ -179,6 +206,16 @@ func BenchmarkQueueSerial(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		q.Peek()
 		q.Remove()
+	}
+}
+
+func BenchmarkQueuePopSerial(b *testing.B) {
+	q := New()
+	for i := 0; i < b.N; i++ {
+		q.Add(nil)
+	}
+	for i := 0; i < b.N; i++ {
+		q.Pop()
 	}
 }
 


### PR DESCRIPTION
This is useful to clear the queue in such a way that does not cause GC, particularly when the queue will be refilled by a similar number of items than it was previously.