### PR TITLE
Remove() returns item removed.

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -83,12 +83,13 @@ func (q *Queue) Get(i int) interface{} {
 	return q.buf[(q.head+i)&(len(q.buf)-1)]
 }
 
-// Remove removes the element from the front of the queue. If you actually
-// want the element, call Peek first. This call panics if the queue is empty.
-func (q *Queue) Remove() {
+// Remove removes and returns the element from the front of the queue. If the
+// queue is empty, the call will panic.
+func (q *Queue) Remove() interface{} {
 	if q.count <= 0 {
 		panic("queue: Remove() called on empty queue")
 	}
+	ret := q.buf[q.head]
 	q.buf[q.head] = nil
 	// bitwise modulus
 	q.head = (q.head + 1) & (len(q.buf) - 1)
@@ -97,4 +98,5 @@ func (q *Queue) Remove() {
 	if len(q.buf) > minQueueLen && (q.count<<2) == len(q.buf) {
 		q.resize()
 	}
+	return ret
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -12,7 +12,10 @@ func TestQueueSimple(t *testing.T) {
 		if q.Peek().(int) != i {
 			t.Error("peek", i, "had value", q.Peek())
 		}
-		q.Remove()
+		x := q.Remove()
+		if x != i {
+			t.Error("remove", i, "had value", x)
+		}
 	}
 }
 


### PR DESCRIPTION
The reason I am suggesting this change is because for many of my uses of queue, I remove an item in each iteration of a loop:
```
for q.Length() > 0 {
    x := q.Remove()
    ...
```
Only in some cases (e.g. your channels) do I find a need to do a Peek() and remove separately.