### PR TITLE
Remove reset timer

### DIFF
--- a/queue_test.go
+++ b/queue_test.go
@@ -162,7 +162,6 @@ func BenchmarkQueueGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		q.Add(i)
 	}
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		q.Get(i)
 	}

--- a/v2/queue_test.go
+++ b/v2/queue_test.go
@@ -162,7 +162,6 @@ func BenchmarkQueueGet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		q.Add(i)
 	}
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		q.Get(i)
 	}


### PR DESCRIPTION
`b.ResetTimer` hangs on when I try to run `BenchmarkQueueGet`.

I removed them and then it works fine.

`$ go test -bench=. -count 5 -run ^# -benchmem`